### PR TITLE
Bot API changes from July 2015

### DIFF
--- a/lib/telegram/bot/types/contact.rb
+++ b/lib/telegram/bot/types/contact.rb
@@ -5,7 +5,7 @@ module Telegram
         attribute :phone_number, String
         attribute :first_name, String
         attribute :last_name, String
-        attribute :user_id, String
+        attribute :user_id, Integer
       end
     end
   end

--- a/lib/telegram/bot/types/message.rb
+++ b/lib/telegram/bot/types/message.rb
@@ -16,6 +16,7 @@ module Telegram
         attribute :photo, Array[PhotoSize]
         attribute :sticker, Sticker
         attribute :video, Video
+        attribute :caption, String
         attribute :contact, Contact
         attribute :location, Location
         attribute :new_chat_participant, User

--- a/lib/telegram/bot/types/video.rb
+++ b/lib/telegram/bot/types/video.rb
@@ -9,7 +9,6 @@ module Telegram
         attribute :thumb, PhotoSize
         attribute :mime_type, String
         attribute :file_size, Integer
-        attribute :caption, String
       end
     end
   end


### PR DESCRIPTION
Applied July 2015 changes to the Telegram Bot API as detailed in the [Changelog]
(https://core.telegram.org/bots/api-changelog#july-2015).

* The *thumb* field is now optional for `Video`, `Sticker` and `Document` objects
* The API now supports both video and photo captions. The *caption* field has been removed from the `Video` object and added to the `Message` object instead.
* *caption* and *duration* optional fields have been added to the `sendVideo` method.
* Fixed typo: *user_id* in the `Contact` object is now correctly labeled as `Integer`, not `String`