### PR TITLE
use snake_case for api methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Telegram::Bot::Client.run(token) do |bot|
   bot.listen do |message|
     case message.text
     when '/start'
-      bot.api.sendMessage(chat_id: message.chat.id, text: "Hello, #{message.from.first_name}")
+      bot.api.send_message(chat_id: message.chat.id, text: "Hello, #{message.from.first_name}")
     when '/stop'
-      bot.api.sendMessage(chat_id: message.chat.id, text: "Bye, #{message.from.first_name}")
+      bot.api.send_message(chat_id: message.chat.id, text: "Bye, #{message.from.first_name}")
     end
   end
 end
@@ -63,11 +63,11 @@ bot.listen do |message|
     answers =
       Telegram::Bot::Types::ReplyKeyboardMarkup
       .new(keyboard: [%w(A B), %w(C D)], one_time_keyboard: true)
-    bot.api.sendMessage(chat_id: message.chat.id, text: question, reply_markup: answers)
+    bot.api.send_message(chat_id: message.chat.id, text: question, reply_markup: answers)
   when '/stop'
     # See more: https://core.telegram.org/bots/api#replykeyboardhide
     kb = Telegram::Bot::Types::ReplyKeyboardHide.new(hide_keyboard: true)
-    bot.api.sendMessage(chat_id: message.chat.id, text: 'Sorry to see you go :(', reply_markup: kb)
+    bot.api.send_message(chat_id: message.chat.id, text: 'Sorry to see you go :(', reply_markup: kb)
   end
 end
 ```

--- a/examples/bot.rb
+++ b/examples/bot.rb
@@ -7,11 +7,11 @@ Telegram::Bot::Client.run(token) do |bot|
   bot.listen do |message|
     case message.text
     when '/start'
-      bot.api.sendMessage(chat_id: message.chat.id, text: "Hello, #{message.from.first_name}!")
+      bot.api.send_message(chat_id: message.chat.id, text: "Hello, #{message.from.first_name}!")
     when '/end'
-      bot.api.sendMessage(chat_id: message.chat.id, text: "Bye, #{message.from.first_name}!")
+      bot.api.send_message(chat_id: message.chat.id, text: "Bye, #{message.from.first_name}!")
     else
-      bot.api.sendMessage(chat_id: message.chat.id, text: "I don't understand you :(")
+      bot.api.send_message(chat_id: message.chat.id, text: "I don't understand you :(")
     end
   end
 end

--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -25,7 +25,10 @@ module Telegram
       end
 
       def method_missing(method_name, *args, &block)
-        ENDPOINTS.include?(method_name.to_s) ? call(method_name, *args) : super
+        method_string = method_name.to_s
+        method_name = camelize(method_string) if method_string.include?('_')
+
+        ENDPOINTS.include?(method_string) ? call(method_name, *args) : super
       end
 
       def call(endpoint, raw_params = {})
@@ -54,6 +57,12 @@ module Telegram
       def jsonify_reply_markup(value)
         return value unless REPLY_MARKUP_TYPES.include?(value.class)
         value.to_h.to_json
+      end
+
+      def camelize(method_name)
+        words = method_name.split('_')
+        words.drop(1).each { |word| word.capitalize! }
+        words.join.to_sym
       end
     end
   end


### PR DESCRIPTION
CamelCase methods like ```bot.api.sendMessage```contradict the [Ruby style guide] (https://github.com/bbatsov/ruby-style-guide). I've added support of snake_case for method_missing in Api class.