### PR TITLE
expose error_code in ResponseError

### DIFF
--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -13,6 +13,10 @@ module Telegram
             format(' (%s)', data.map { |k, v| %(#{k}: "#{v}") }.join(', '))
         end
 
+        def error_code
+          data[:error_code] || data["error_code"]
+        end
+
         private
 
         def data


### PR DESCRIPTION
This addresses Issue #20. Accessing both the symbol name and string is necessary, since the fallback from the JSON failing to be parsed uses the symbol `:error_code`, but the actual JSON key is a string.