### PR TITLE
Fixed fail on empty from field

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -58,8 +58,9 @@ module Telegram
       end
 
       def log_incoming_message(message)
+        uid = message.from ? message.from.id : nil
         logger.info(
-          format('Incoming message: text="%s" uid=%i', message, message.from.id)
+          format('Incoming message: text="%s" uid=%s', message, uid)
         )
       end
     end


### PR DESCRIPTION
Hi,

`message.from` can be nil (https://core.telegram.org/bots/api#message).

In that case the gem throws an exception.
I've found basic specs only. Should I write a spec for this case?