### PR TITLE
Add `forward_from_message_id` to Types::Message

### DIFF
--- a/lib/telegram/bot/types/message.rb
+++ b/lib/telegram/bot/types/message.rb
@@ -8,6 +8,7 @@ module Telegram
         attribute :chat, Chat
         attribute :forward_from, User
         attribute :forward_from_chat, Chat
+        attribute :forward_from_message_id, Integer
         attribute :forward_date, Integer
         attribute :reply_to_message, Message
         attribute :edit_date, Integer


### PR DESCRIPTION
According to Bot API 2.3 [CHANGELOG](https://core.telegram.org/bots/api-changelog#november-21-2016)

> Added the new field forward_from_message_id to Message.