### PR TITLE
better client options handling

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -1,7 +1,7 @@
 module Telegram
   module Bot
     class Client
-      attr_reader :api, :offset, :timeout
+      attr_reader :api, :options
       attr_accessor :logger
 
       def self.run(*args, &block)
@@ -9,11 +9,9 @@ module Telegram
       end
 
       def initialize(token, h = {})
-        options = default_options.merge(h)
+        @options = default_options.merge(h)
         @api = Api.new(token)
-        @offset = options[:offset]
-        @timeout = options[:timeout]
-        @logger = options[:logger]
+        @logger = options.delete(:logger)
       end
 
       def run
@@ -29,12 +27,12 @@ module Telegram
       end
 
       def fetch_updates
-        response = api.getUpdates(offset: offset, timeout: timeout)
+        response = api.getUpdates(options)
         return unless response['ok']
 
         response['result'].each do |data|
           update = Types::Update.new(data)
-          @offset = update.update_id.next
+          @options[:offset] = update.update_id.next
           message = extract_message(update)
           log_incoming_message(message)
           yield message

--- a/spec/lib/telegram/bot/client_spec.rb
+++ b/spec/lib/telegram/bot/client_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Telegram::Bot::Client do
+  let(:token)  { '180956132:AAHU0_CeyQWOd6baBc9TibTPybxY9p1P8xo' }
+  let(:client) { described_class.new(token, options) }
+
+  describe '#new' do
+    subject { client.options }
+
+    context 'with any options' do
+      let(:options) { { offset: 1, timeout: 30, something: true } }
+
+      it 'accepts any option' do
+        is_expected.to eql(options)
+      end
+    end
+
+    context 'with logger option' do
+      let(:options) { { offset: 1, timeout: 30, something: true, logger: Logger.new('/dev/null') } }
+
+      it 'removes logger from options' do
+        is_expected.not_to include(:logger)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello!

What about accepting any option on `Telegram::Bot::Client.new`, so we don't have to update the code at each telegram `getUpdates` change?
For example `allowed_updates` and `limit` options are missing at the moment... https://core.telegram.org/bots/api#getupdates
