### PR TITLE
fix bug with getting message

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -48,11 +48,14 @@ module Telegram
       end
 
       def extract_message(update)
-        update.inline_query ||
-          update.chosen_inline_result ||
-          update.callback_query ||
-          update.edited_message ||
-          update.message
+        types = %w(inline_query
+                   chosen_inline_result
+                   callback_query
+                   edited_message
+                   message
+                   channel_post
+                   edited_channel_post)
+        types.inject(nil) { |acc, elem| acc || update.send(elem) }
       end
 
       def log_incoming_message(message)


### PR DESCRIPTION
When bot added to channel bot crashed with error 
`/usr/local/rvm/gems/ruby-2.3.3/gems/telegram-bot-ruby-0.7.1/lib/telegram/bot/client.rb:59:in 'log_incoming_message': undefined method 'from' for nil:NilClass (NoMethodError)`
That was because Types::Update now can have new fields: channel_post, edited_channel_post (like it was described in issue #82)
After changes made here my bot works correctly in channels