### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ end
 If you don't know how to setup database for your bot or how to use it with different languages here are some boilerplates which can help you to start faster:
 - [Ruby Telegram Bot boilerplate](https://github.com/telegram-bots/ruby-telegram-bot-boilerplate)
 
+Test on [RapidAPI](https://rapidapi.com/package/TelegramBot/functions?utm_source=TelegramGitHub&utm_medium=button)
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
I've added a link in your README to Telegram's functions page in RapidAPI. I've done this for a few Telegram SDKs to help those who are reading the READMEs, understand and test the API before use.