### PR TITLE
Added Api#in_parallel method to make request in parallel.

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -66,10 +66,16 @@ module Telegram
         response = conn.post("/bot#{token}/#{endpoint}", params)
         if response.status == 200
           JSON.parse(response.body)
-        else
+        elsif response.finished?
           raise Exceptions::ResponseError.new(response),
                 'Telegram API has returned the error.'
+        else
+          response
         end
+      end
+
+      def in_parallel(&block)
+        conn.in_parallel(&block)
       end
 
       private


### PR DESCRIPTION
Hi,
I was investigating if it was possible to notify a huge number of users using this gem.

Since you are using `faraday` under the hood, I have adapted the `Api` module to make use of the `in_parallel` method provided in some faraday adapters.

I'm not sure if I have missed something, so I will be grateful if you can provide some feedback on this.

Regards.

Usage example:

```ruby
require 'telegram/bot'
require 'typhoeus/adapters/faraday'

token = 'MY_TOKEN'

Telegram::Bot.configure do |config|
  config.adapter = :typhoeus
end

Telegram::Bot::Client.run(token) do |bot|
  bot.listen do |message|
    case message.text
    when '/start'
      responses = []
      # All the request are fired after the in_parallel block
      bot.api.in_parallel do
        responses = (0..10).map do |i|
          bot.api.send_message(chat_id: message.chat.id, text: "Hello, #{message.from.first_name}, message #{i}")
        end
      end
      # Do something with the responses
      responses.each do |response|
        puts response.body
      end
    end
  end
end
```
