### PR TITLE
Move extracting message logic to mixin

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -1,6 +1,10 @@
+require 'telegram/bot/client/extractable'
+
 module Telegram
   module Bot
     class Client
+      include Extractable
+
       attr_reader :api, :options
       attr_accessor :logger
 
@@ -45,17 +49,6 @@ module Telegram
 
       def default_options
         { offset: 0, timeout: 20, logger: NullLogger.new }
-      end
-
-      def extract_message(update)
-        types = %w(inline_query
-                   chosen_inline_result
-                   callback_query
-                   edited_message
-                   message
-                   channel_post
-                   edited_channel_post)
-        types.inject(nil) { |acc, elem| acc || update.public_send(elem) }
       end
 
       def log_incoming_message(message)

--- a/lib/telegram/bot/client/extractable.rb
+++ b/lib/telegram/bot/client/extractable.rb
@@ -1,0 +1,22 @@
+module Telegram
+  module Bot
+    class Client
+      module Extractable
+        private
+
+        def extract_message(update)
+          types = %w(
+            inline_query
+            chosen_inline_result
+            callback_query
+            edited_message
+            message
+            channel_post
+            edited_channel_post
+          )
+          types.inject(nil) { |acc, elem| acc || update.public_send(elem) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi @atipugin,

currently extracting message from update is implemented within `Client#extract_method` so it can be used only with long-polling bot (correct me if I am wrong).

With webhook bot one should implement this logic manually.

I propose to move this logic somewhere (I end up with some kind of mixin) to be able to reuse it.
With this patch applied I can write Rack listener like this.

```
# config.ru
class Listener
  include Telegram::Bot::Client::Extractable

  def call(env)
    req = Rack::Request.new(env)

    update = Telegram::Bot::Types::Update.new(req.params)
    message = extract_message(update)

    # processing logic here, message can be callback_query, inline_query, message, etc.
  end
end
```

What do you think?