### PR TITLE
Implement Bot API 3.3

### DIFF
--- a/lib/telegram/bot.rb
+++ b/lib/telegram/bot.rb
@@ -1,4 +1,5 @@
 require 'virtus'
+require 'inflecto'
 require 'logger'
 require 'json'
 require 'faraday'

--- a/lib/telegram/bot/types.rb
+++ b/lib/telegram/bot/types.rb
@@ -66,3 +66,5 @@ require 'telegram/bot/types/labeled_price'
 require 'telegram/bot/types/shipping_option'
 require 'telegram/bot/types/chat_member'
 require 'telegram/bot/types/user_profile_photos'
+
+Virtus.finalize

--- a/lib/telegram/bot/types.rb
+++ b/lib/telegram/bot/types.rb
@@ -1,3 +1,4 @@
+require 'telegram/bot/types/compactable'
 require 'telegram/bot/types/base'
 require 'telegram/bot/types/user'
 require 'telegram/bot/types/audio'

--- a/lib/telegram/bot/types/base.rb
+++ b/lib/telegram/bot/types/base.rb
@@ -3,19 +3,7 @@ module Telegram
     module Types
       class Base
         include Virtus.model
-
-        def to_compact_hash
-          Hash[attributes.dup.delete_if { |_, v| v.nil? }.map do |key, value|
-            value =
-              if value.class.ancestors.include?(Telegram::Bot::Types::Base)
-                value.to_compact_hash
-              else
-                value
-              end
-
-            [key, value]
-          end]
-        end
+        include Compactable
       end
     end
   end

--- a/lib/telegram/bot/types/chat.rb
+++ b/lib/telegram/bot/types/chat.rb
@@ -2,6 +2,8 @@ module Telegram
   module Bot
     module Types
       class Chat < Base
+        include Virtus.model(finalize: false)
+
         attribute :id, Integer
         attribute :type, String
         attribute :title, String
@@ -12,6 +14,7 @@ module Telegram
         attribute :photo, ChatPhoto
         attribute :description, String
         attribute :invite_link, String
+        attribute :pinned_message, 'Telegram::Bot::Types::Message'
       end
     end
   end

--- a/lib/telegram/bot/types/chat.rb
+++ b/lib/telegram/bot/types/chat.rb
@@ -1,8 +1,9 @@
 module Telegram
   module Bot
     module Types
-      class Chat < Base
+      class Chat
         include Virtus.model(finalize: false)
+        include Compactable
 
         attribute :id, Integer
         attribute :type, String

--- a/lib/telegram/bot/types/compactable.rb
+++ b/lib/telegram/bot/types/compactable.rb
@@ -1,0 +1,20 @@
+module Telegram
+  module Bot
+    module Types
+      module Compactable
+        def to_compact_hash
+          Hash[attributes.dup.delete_if { |_, v| v.nil? }.map do |key, value|
+            value =
+              if value.class.ancestors.include?(Telegram::Bot::Types::Base)
+                value.to_compact_hash
+              else
+                value
+              end
+
+            [key, value]
+          end]
+        end
+      end
+    end
+  end
+end

--- a/lib/telegram/bot/types/message.rb
+++ b/lib/telegram/bot/types/message.rb
@@ -9,9 +9,11 @@ module Telegram
         attribute :forward_from, User
         attribute :forward_from_chat, Chat
         attribute :forward_from_message_id, Integer
+        attribute :forward_signature, String
         attribute :forward_date, Integer
         attribute :reply_to_message, Message
         attribute :edit_date, Integer
+        attribute :author_signature, String
         attribute :text, String
         attribute :entities, Array[MessageEntity]
         attribute :audio, Audio

--- a/lib/telegram/bot/types/user.rb
+++ b/lib/telegram/bot/types/user.rb
@@ -3,6 +3,7 @@ module Telegram
     module Types
       class User < Base
         attribute :id, Integer
+        attribute :is_bot, Boolean
         attribute :first_name, String
         attribute :last_name, String
         attribute :username, String

--- a/telegram-bot-ruby.gemspec
+++ b/telegram-bot-ruby.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday'
   spec.add_dependency 'virtus'
+  spec.add_dependency 'inflecto'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Hi @atipugin,

I have made [Bot API 3.3](https://core.telegram.org/bots/api-changelog#august-23-2017) updates.

This one is tricky. Now we have a circular dependency between `Chat` and `Message`.
I found Virtus [documentation](https://github.com/solnic/virtus/blob/master/README.md#attribute-finalization-and-circular-dependencies) about that.

However Virtus complains about namespaced types,
> Virtus needs inflecto gem to constantize namespaced constant names (NotImplementedError)

so we should use `inflecto` 😐 

I have tested it in console, it seems to work fine.