### PR TITLE
Bot API 3.5 updates

### DIFF
--- a/lib/telegram/bot/types.rb
+++ b/lib/telegram/bot/types.rb
@@ -67,5 +67,7 @@ require 'telegram/bot/types/labeled_price'
 require 'telegram/bot/types/shipping_option'
 require 'telegram/bot/types/chat_member'
 require 'telegram/bot/types/user_profile_photos'
+require 'telegram/bot/types/input_media_photo'
+require 'telegram/bot/types/input_media_video'
 
 Virtus.finalize

--- a/lib/telegram/bot/types/input_media_photo.rb
+++ b/lib/telegram/bot/types/input_media_photo.rb
@@ -2,7 +2,7 @@ module Telegram
   module Bot
     module Types
       class InputMediaPhoto < Base
-        attribute :type, String
+        attribute :type, String, default: 'photo'
         attribute :media, String
         attribute :caption, String
       end

--- a/lib/telegram/bot/types/input_media_video.rb
+++ b/lib/telegram/bot/types/input_media_video.rb
@@ -2,7 +2,7 @@ module Telegram
   module Bot
     module Types
       class InputMediaVideo < Base
-        attribute :type, String
+        attribute :type, String, default: 'video'
         attribute :media, String
         attribute :caption, String
         attribute :width, Integer


### PR DESCRIPTION
Hi @atipugin,

This one fixes #163 by adding `require`.
Also it adds default type value for `Types::InputMedia` to allow to skip `type` attribute in constructor.