### PR TITLE
prevented message logging if the text is nil

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -34,8 +34,10 @@ module Telegram
           update = Types::Update.new(data)
           @options[:offset] = update.update_id.next
           message = update.current_message
-          log_incoming_message(message)
-          yield message
+          unless message.test.nil?
+            log_incoming_message(message)
+            yield message
+          end
         end
       rescue Faraday::Error::TimeoutError
         retry

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -34,7 +34,7 @@ module Telegram
           update = Types::Update.new(data)
           @options[:offset] = update.update_id.next
           message = update.current_message
-          unless message.test.nil?
+          unless message.text.nil?
             log_incoming_message(message)
             yield message
           end


### PR DESCRIPTION
Hello and thanks for having nice and convenient ruby wrapper for telegram bots :)
I've recently found an issue when gem crashed after I tried to add my bot to the chat - he recognised this "adding to chat" message as a nil-message and was crashing all the time. I tried to apply fix for this situation.
Thanks!