### PR TITLE
use proxy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,34 @@ Telegram::Bot.configure do |config|
 end
 ```
 
+## Use Proxy
+
+You can use socks5 or another proxy, for this, create the `telegram.rb` file in the initializers and set the proxy server settings.
+
+```ruby
+
+# https proxy example
+Telegram::Bot.configure do |config|
+  config.ssl_opts = {verify: true}
+  config.proxy_opts = {
+    uri:  'https://your_proxy_ip:port',
+    socks: false
+  }
+end
+
+# sock5 proxy example
+Telegram::Bot.configure do |config|
+  config.ssl_opts = {verify: false}
+  config.proxy_opts = {
+    uri:  'https://your_proxy_ip:port',
+    user: 'your login',
+    password: 'your pass',
+    socks: true
+  }
+end
+
+```
+
 ## Boilerplates
 
 If you don't know how to setup database for your bot or how to use it with different languages here are some boilerplates which can help you to start faster:

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -1,0 +1,38 @@
+require 'socksify'
+require 'socksify/http'
+module Faraday
+  class Adapter
+    class NetHttp
+      def net_http_connection(env)
+        proxy = Telegram::Bot.configuration.proxy_opts
+        if proxy
+          env[:ssl] ||= Telegram::Bot.configuration.ssl_opts
+          if proxy[:socks]
+            sock_proxy(proxy)
+          else
+            http_proxy(proxy)
+          end
+        else
+          Net::HTTP
+        end.new(env[:url].host, env[:url].port)
+      end
+
+      private
+
+      def sock_proxy(proxy)
+        proxy_uri = URI.parse(proxy[:uri])
+        TCPSocket.socks_username = proxy[:user] if proxy[:user]
+        TCPSocket.socks_password = proxy[:password] if proxy[:password]
+        Net::HTTP::SOCKSProxy(proxy_uri.host, proxy_uri.port)
+      end
+
+      def http_proxy(proxy)
+        proxy_uri = URI.parse(proxy[:uri])
+        Net::HTTP::Proxy(proxy_uri.host,
+                         proxy_uri.port,
+                         proxy_uri.user,
+                         proxy_uri.password)
+      end
+    end
+  end
+end

--- a/lib/telegram/bot/configuration.rb
+++ b/lib/telegram/bot/configuration.rb
@@ -1,7 +1,8 @@
+require 'faraday/adapter/net_http'
 module Telegram
   module Bot
     class Configuration
-      attr_accessor :adapter
+      attr_accessor :adapter, :proxy_opts, :ssl_opts
 
       def initialize
         @adapter = Faraday.default_adapter

--- a/telegram-bot-ruby.gemspec
+++ b/telegram-bot-ruby.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday'
   spec.add_dependency 'virtus'
   spec.add_dependency 'inflecto'
+  spec.add_dependency 'socksify'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
In connection with the blocking of Telegram in Russia, the possibility of using a proxy is very important.
It solve [how to substitute the https://api.telegram.org end-point with proxy? #63 issue](https://github.com/atipugin/telegram-bot-ruby/issues/63)