### PR TITLE
Fixed to_compact_hash not working on Chat and Array object

### DIFF
--- a/lib/telegram/bot/types/chat.rb
+++ b/lib/telegram/bot/types/chat.rb
@@ -1,7 +1,7 @@
 module Telegram
   module Bot
     module Types
-      class Chat
+      class Chat < Base
         include Virtus.model(finalize: false)
         include Compactable
 

--- a/lib/telegram/bot/types/compactable.rb
+++ b/lib/telegram/bot/types/compactable.rb
@@ -4,15 +4,21 @@ module Telegram
       module Compactable
         def to_compact_hash
           Hash[attributes.dup.delete_if { |_, v| v.nil? }.map do |key, value|
-            value =
-              if value.class.ancestors.include?(Telegram::Bot::Types::Base)
-                value.to_compact_hash
-              else
-                value
-              end
-
+            value = recursive_hash_conversion(value)
             [key, value]
           end]
+        end
+
+        private
+
+        def recursive_hash_conversion(value)
+          if value.class.ancestors.include?(Telegram::Bot::Types::Base)
+            value.to_compact_hash
+          elsif value.is_a?(Array)
+            value.map { |arr_content| recursive_hash_conversion(arr_content) }
+          else
+            value
+          end
         end
       end
     end


### PR DESCRIPTION
For an object `message` of type `Telegram::Bot::Types::Message`, if you call

```
message.to_compact_hash
```

The `chat` and `entities` attribute don't get converted to a hash.

I fixed it by making `Chat` class inherit `Base` (because the condition on calling `to_compact_hash` in the method is only checking whether the class inherits Base or not). Another alternative is by adding additional inherited class in the condition (`Telegram::Bot::Types::Compactable`)

Also, arrays of compactables don't get converted properly, I setup recursive method to convert arrays too.