### PR TITLE
Allow stopping poller

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -20,10 +20,7 @@ module Telegram
 
       def listen(&block)
         logger.info('Starting bot')
-        running = true
-        Signal.trap('INT') { running = false }
-        fetch_updates(&block) while running
-        exit
+        fetch_updates(&block)
       end
 
       def fetch_updates

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -20,8 +20,12 @@ module Telegram
 
       def listen(&block)
         logger.info('Starting bot')
-        running = true
-        fetch_updates(&block) while running
+        @running = true
+        fetch_updates(&block) while @running
+      end
+
+      def stop
+        @running = false
       end
 
       def fetch_updates

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -20,7 +20,8 @@ module Telegram
 
       def listen(&block)
         logger.info('Starting bot')
-        fetch_updates(&block)
+        running = true
+        fetch_updates(&block) while running
       end
 
       def fetch_updates

--- a/lib/telegram/bot/version.rb
+++ b/lib/telegram/bot/version.rb
@@ -1,5 +1,5 @@
 module Telegram
   module Bot
-    VERSION = '0.8.6.1'.freeze
+    VERSION = '0.8.7.0'.freeze
   end
 end


### PR DESCRIPTION
Libraries should not intercept SIGINT or handle `exit`ing it's process or thread. This PR provides a method interface for cleanly stopping the poller via `.stop` while allowing SIGINT to be handled by the application developer.

Includes patch version bump.