### PR TITLE
Missed media_group_id attr for Message object was added

### DIFF
--- a/lib/telegram/bot/types/message.rb
+++ b/lib/telegram/bot/types/message.rb
@@ -13,6 +13,7 @@ module Telegram
         attribute :forward_date, Integer
         attribute :reply_to_message, Message
         attribute :edit_date, Integer
+        attribute :media_group_id, String
         attribute :author_signature, String
         attribute :text, String
         attribute :entities, Array[MessageEntity]


### PR DESCRIPTION
Hello! Thank u for awesome gem.

I found some problem with implemented attributes list of message object.
- `media_group_id` string attribute was missed in `telegram-bot-ruby/lib/telegram/bot/types/message.rb`.

My PR solves this problem.