### PR TITLE
switching the command Faraday::Error::TimeoutError

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -37,7 +37,7 @@ module Telegram
           log_incoming_message(message)
           yield message
         end
-      rescue Faraday::Error::TimeoutError
+      rescue Faraday::TimeoutError
         retry
       end
 


### PR DESCRIPTION
the command Faraday::Error::TimeoutError doesn't exist anymore, was replaced for this command Faraday::TimeoutError