### PR TITLE
Fix send_media_group for multiple Photos/Videos

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -45,7 +45,9 @@ module Telegram
         Telegram::Bot::Types::InlineQueryResultCachedDocument,
         Telegram::Bot::Types::InlineQueryResultCachedVideo,
         Telegram::Bot::Types::InlineQueryResultCachedVoice,
-        Telegram::Bot::Types::InlineQueryResultCachedAudio
+        Telegram::Bot::Types::InlineQueryResultCachedAudio,
+        Telegram::Bot::Types::InputMediaPhoto,
+        Telegram::Bot::Types::InputMediaVideo
       ].freeze
 
       attr_reader :token, :url


### PR DESCRIPTION
This fixes https://github.com/atipugin/telegram-bot-ruby/issues/184