### PR TITLE
[Message] Add `parse_mode` attribute

### DIFF
--- a/lib/telegram/bot/types/message.rb
+++ b/lib/telegram/bot/types/message.rb
@@ -51,6 +51,7 @@ module Telegram
         attribute :connected_website, String
         attribute :passport_data, PassportData
         attribute :reply_markup, InlineKeyboardMarkup
+        attribute :parse_mode, String
 
         alias to_s text
       end


### PR DESCRIPTION
As stated here: https://core.telegram.org/bots/api#sendmessage
The message type seems to supports a `parse_mode` attribute that can be used for formatting text.

This was missing from `lib/telegram/bot/types/message.rb`.