### PR TITLE
Add pattern matching support for Telegram types

### DIFF
--- a/lib/telegram/bot/types.rb
+++ b/lib/telegram/bot/types.rb
@@ -1,4 +1,5 @@
 require 'telegram/bot/types/compactable'
+require 'telegram/bot/types/pattern_matching'
 require 'telegram/bot/types/base'
 require 'telegram/bot/types/user'
 require 'telegram/bot/types/photo_size'

--- a/lib/telegram/bot/types/base.rb
+++ b/lib/telegram/bot/types/base.rb
@@ -4,6 +4,7 @@ module Telegram
       class Base
         include Virtus.model
         include Compactable
+        include PatternMatching
       end
     end
   end

--- a/lib/telegram/bot/types/chat.rb
+++ b/lib/telegram/bot/types/chat.rb
@@ -4,6 +4,7 @@ module Telegram
       class Chat
         include Virtus.model(finalize: false)
         include Compactable
+        include PatternMatching
 
         attribute :id, Integer
         attribute :type, String

--- a/lib/telegram/bot/types/pattern_matching.rb
+++ b/lib/telegram/bot/types/pattern_matching.rb
@@ -1,0 +1,11 @@
+module Telegram
+  module Bot
+    module Types
+      module PatternMatching
+        def deconstruct_keys(_keys)
+          attributes
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for [pattern-matching](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html) Telegram types.

Some silly example:

```rb
update = Telegram::Bot::Api::Update.new(payload)

include Telegram::Bot::Api::Types

case update
in Update(message: Message(text: text, from: User(id: telegram_id, is_bot: false)))
  bot.api.send_message(chat_id: telegram_id, text: text.reverse)
in Update(message: Message(text: text, from: User(id: telegram_id, is_bot: true)))
  bot.api.send_message(chat_id: telegram_id, text: 'No bots allowed!')
else
  # unsupported update type
end
```