### PR TITLE
Call #to_compact_hash on all objects responding to it

### DIFF
--- a/lib/telegram/bot/types/compactable.rb
+++ b/lib/telegram/bot/types/compactable.rb
@@ -5,7 +5,7 @@ module Telegram
         def to_compact_hash
           Hash[attributes.dup.delete_if { |_, v| v.nil? }.map do |key, value|
             value =
-              if value.class.ancestors.include?(Telegram::Bot::Types::Base)
+              if value.respond_to?(:to_compact_hash)
                 value.to_compact_hash
               else
                 value


### PR DESCRIPTION
The current implementation of `Compactable#to_compact_hash` checks if a value inherits from `Types::Base`, which unfortunately is not the case for `Types::Chat`. So when we call `#to_compact_hash` for any `Types::Base` object that recursively contains a `Types::Chat` object, all values except for the chat object are converted to hash.

## Steps to reproduce

```rb
update = Telegram::Bot::Types::Update.new(message: { chat: { id: 1 }, text: '/start' })
puts update.to_compact_hash
```

## Expected behavior

The whole update is recursively converted to hash:

```rb
{:message=>{:chat=>{:id=>1}, :text=>"/start", :entities=>[], :caption_entities=>[], :photo=>[], :new_chat_members=>[], :new_chat_photo=>[]}
```

## Actual behavior

The following hash is printed (note that `:chat` is not converted to hash):

```rb
{:message=>{:chat=>#<Telegram::Bot::Types::Chat:0x000000000f74bd00 @id=1, @type=nil, @title=nil, @username=nil, @first_name=nil, @last_name=nil, @all_members_are_administrators=nil, @photo=nil, @description=nil, @invite_link=nil, @pinned_message=nil>, :text=>"/start", :entities=>[], :caption_entities=>[], :photo=>[], :new_chat_members=>[], :new_chat_photo=>[]}}
```

## Alternative

Since including a module inserts it into the inheritance chain, we could also check if the value is a subclass of `Types::Compactable`:

```rb
if value.is_a?(Compactable)
  value.to_compact_hash
else
  value
end
```

But I settled on calling `#respond_to?` because it's considered more idiomatic.