### PR TITLE
Add activesupport support

### DIFF
--- a/lib/telegram/bot/types/compactable.rb
+++ b/lib/telegram/bot/types/compactable.rb
@@ -3,20 +3,22 @@ module Telegram
     module Types
       module Compactable
         def to_compact_hash
-          Hash[attributes.dup.delete_if { |_, v| v.nil? }.map do |key, value|
-            value =
-              if value.respond_to?(:to_compact_hash)
-                value.to_compact_hash
-              else
-                value
-              end
+          attributes.inject({}) do |acc, (key, value)|
+            next acc if value.nil?
 
-            [key, value]
-          end]
+            value = value.to_compact_hash if value.respond_to?(:to_compact_hash)
+
+            acc[key] = value
+            acc
+          end
         end
 
         def to_json(*args)
           to_compact_hash.select { |_, v| v }.to_json(*args)
+        end
+
+        def as_json(*args)
+          to_compact_hash.select { |_, v| v }.as_json(*args)
         end
       end
     end

--- a/spec/lib/telegram/bot/types/compactable_spec.rb
+++ b/spec/lib/telegram/bot/types/compactable_spec.rb
@@ -1,0 +1,37 @@
+require 'pry'
+
+RSpec.describe Telegram::Bot::Types::Compactable do
+  let(:dummy_class) { Struct.new(:a, :b).include(described_class) }
+  let(:dummy_instance) { dummy_class.new(1, nil) }
+
+  before do
+    allow(dummy_instance).to receive(:attributes).and_return(
+      { a: dummy_instance.a, b: dummy_instance.b }
+    )
+  end
+
+  describe '.to_compact_hash' do
+    it 'compacts hash' do
+      expect(dummy_instance.to_compact_hash).to eq({a: 1})
+    end
+  end
+
+  describe '.to_json' do
+    it 'returns json without b key' do
+      result = JSON.generate([dummy_instance])
+      expect(JSON.parse(result)).to eq([{"a" => 1}])
+    end
+  end
+
+  context 'when activesupport applied' do
+    describe '.as_json' do
+      it 'returns json without b key' do
+        require "active_support"
+        require "active_support/core_ext/object/json"
+
+        result = [dummy_instance].to_json
+        expect(JSON.parse(result)).to eq([{"a" => 1}])
+      end
+    end
+  end
+end

--- a/telegram-bot-ruby.gemspec
+++ b/telegram-bot-ruby.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rubocop', '~> 0.48.1'
+  spec.add_development_dependency 'activesupport', '>= 5.0'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.8'
 end


### PR DESCRIPTION
I've got this message when using the gem:
```
Telegram::Bot::Exceptions::ResponseError: Telegram API has returned the error. (ok: "false", error_code: "400", description: "Bad Request: can't parse inline query result: Field "url" must be of type String")
```

This was because activesupport calls `as_json` instead `to_json` while using `to_json` on an array. And the objects (`Telegram::Bot::Types::InputTextMessageContent.new`) didn't compact.

This PR fix it

Also I rewrote `to_compact_hash` method. Now it runs faster and creates less objects.