### PR TITLE
Global timeout configuration

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -88,6 +88,8 @@ module Telegram
           faraday.request :multipart
           faraday.request :url_encoded
           faraday.adapter Telegram::Bot.configuration.adapter
+          faraday.options.timeout = Telegram::Bot.configuration.timeout
+          faraday.options.open_timeout = Telegram::Bot.configuration.open_timeout
         end
       end
     end

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -33,7 +33,7 @@ module Telegram
         response['result'].each do |data|
           yield handle_update(Types::Update.new(data))
         end
-      rescue Faraday::TimeoutError
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed
         retry
       end
 
@@ -50,7 +50,6 @@ module Telegram
       def default_options
         {
           offset: 0,
-          timeout: 20,
           logger: NullLogger.new,
           url: 'https://api.telegram.org'
         }

--- a/lib/telegram/bot/configuration.rb
+++ b/lib/telegram/bot/configuration.rb
@@ -1,10 +1,12 @@
 module Telegram
   module Bot
     class Configuration
-      attr_accessor :adapter
+      attr_accessor :adapter, :open_timeout, :timeout
 
       def initialize
         @adapter = Faraday.default_adapter
+        @open_timeout = 20
+        @timeout = 20
       end
     end
   end

--- a/spec/lib/telegram/bot/api_spec.rb
+++ b/spec/lib/telegram/bot/api_spec.rb
@@ -26,6 +26,38 @@ RSpec.describe Telegram::Bot::Api do
           .to raise_error(Telegram::Bot::Exceptions::ResponseError)
       end
     end
+
+    context 'with global timeout' do
+      context 'with low timeout' do
+        before do
+          Telegram::Bot.configure { |config| config.timeout = 0.001 }
+        end
+
+        after do
+          Telegram::Bot.configure { |config| config.timeout = 30 }
+        end
+
+        it 'raises an error' do
+          expect { api_call }
+            .to raise_error(Faraday::TimeoutError)
+        end
+      end
+
+      context 'with low open_timeout' do
+        before do
+          Telegram::Bot.configure { |config| config.open_timeout = 0.001 }
+        end
+
+        after do
+          Telegram::Bot.configure { |config| config.open_timeout = 30 }
+        end
+
+        it 'raises an error' do
+          expect { api_call }
+            .to raise_error(Faraday::ConnectionFailed)
+        end
+      end
+    end
   end
 
   describe '#method_missing' do


### PR DESCRIPTION
It looks like current gem logic does not allow global timeout configuration.
Now user can set timeouts only for each request separately. 
And timeout for Telegram::Bot::Client works only for getUpdates requests.
In current implementation timeout for getUpdates request does not changed by default.

I hope it will be useful for global telegram bot configuration.
