### PR TITLE
Added Test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ end
 
 Note that `bot.api` object implements [Telegram Bot API methods](https://core.telegram.org/bots/api#available-methods) as is. So you can invoke any method inside the block without any problems. All methods are available in both *snake_case* and *camelCase* notations.
 
+If you need to start a bot on development mode you have to pass `enviroment: :test` <br>
+example: `Telegram::Bot::Client.run(token, enviroment: :test)` 
+
 Same thing about `message` object - it implements [Message](https://core.telegram.org/bots/api#message) spec, so you always know what to expect from it.
 
 ## Webhooks

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -12,7 +12,7 @@ module Telegram
 
       def initialize(token, hash = {})
         @options = default_options.merge(hash)
-        @api = Api.new(token, url: options.delete(:url))
+        @api = Api.new(token, url: options.delete(:url), environment: options.delete(:environment))
         @logger = options.delete(:logger)
       end
 
@@ -53,7 +53,8 @@ module Telegram
         {
           offset: 0,
           logger: NullLogger.new,
-          url: 'https://api.telegram.org'
+          url: 'https://api.telegram.org',
+          environment: :production
         }
       end
 

--- a/spec/lib/telegram/bot/api_spec.rb
+++ b/spec/lib/telegram/bot/api_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Telegram::Bot::Api do
-  let(:token) { '180956132:AAHU0_CeyQWOd6baBc9TibTPybxY9p1P8xo' }
+  let(:token) { ENV.fetch('BOT_API_TOKEN') }
+  let(:environment) { ENV.fetch('BOT_API_ENV', :test) }
   let(:endpoint) { 'getMe' }
-  let(:api) { described_class.new(token) }
+  let(:api) { described_class.new(token, environment: environment) }
 
   describe '#call' do
     subject(:api_call) { api.call(endpoint) }

--- a/spec/lib/telegram/bot/client_spec.rb
+++ b/spec/lib/telegram/bot/client_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Telegram::Bot::Client do
+  let(:token) { ENV.fetch('BOT_API_TOKEN') }
+  let(:environment) { ENV.fetch('BOT_API_ENV', :test) }
+
+  describe '#run' do
+    it 'returns hash' do
+      Telegram::Bot::Client.run(token, environment: environment) do |bot|
+        result = bot.api.getMe
+        expect(result).to be_a(Hash)
+        expect(result).to have_key('result')
+        expect(result).to have_key('ok')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi. I added the support of environments to  bots.
This required for  developing Web Applications if you want to run it without ssl.
More info here: https://core.telegram.org/bots/webapps#testing-web-apps

I moved your token to ENV variable.
You can run test with help this command:
`BOT_API_TOKEN=<TOKEN>  bundle exec rspec spec`   