### PR TITLE
Add Telegram::Bot::Api#file

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -62,6 +62,15 @@ module Telegram
         JSON.parse(response.body)
       end
 
+      def file(file_path)
+        response = conn.get("/file/bot#{token}/#{file_path}")
+        unless response.status == 200
+          raise Exceptions::ResponseError.new(response), 'Telegram API has returned an error.'
+        end
+
+        response.body
+      end
+
       private
 
       def build_params(params)


### PR DESCRIPTION
This method can be used to download media after calling `#getFile`

## Usage

```ruby
# Select second tallest photo
def select_photo_by_height(notification)
  photos = notification.photo.sort_by(&:height)
  photos[-2]
end

client = ::Telegram::Bot::Client.new(ENV["bot_token"])
photo = select_photo_by_height(notification)
resp = client.api.get_file(file_id: photo.file_id)
raise "Invalid response from telegram: #{JSON.dump(resp)}" unless resp["ok"]

data = client.api.file(resp.dig("result", "file_path")) # binary data
```