### PR TITLE
Add running attribute to Client for better testing

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -3,7 +3,7 @@
 module Telegram
   module Bot
     class Client
-      attr_reader :api, :options
+      attr_reader :api, :options, :running
       attr_accessor :logger
 
       def self.run(*args, &block)
@@ -22,10 +22,9 @@ module Telegram
 
       def listen(&block)
         logger.info('Starting bot')
-        running = true
-        Signal.trap('INT') { running = false }
+        @running = true
+        Signal.trap('INT') { @running = false }
         fetch_updates(&block) while running
-        exit
       end
 
       def fetch_updates

--- a/spec/lib/telegram/bot/client_spec.rb
+++ b/spec/lib/telegram/bot/client_spec.rb
@@ -11,4 +11,22 @@ RSpec.describe Telegram::Bot::Client do
       expect(client.api.getMe).to include('ok', 'result')
     end
   end
+
+  describe '#listen' do
+    subject(:listen) { client.listen }
+
+    let(:api) { double }
+    let(:response) { { "ok" => true, "result" => [] } }
+
+    before do
+      allow(client).to receive(:running).and_return(true, true, false)
+      allow(client).to receive(:api).and_return(api)
+      allow(api).to receive(:getUpdates).and_return(response)
+    end
+
+    it 'returns hash' do
+      listen
+      expect(api).to have_received(:getUpdates).exactly(2).times
+    end
+  end
 end

--- a/spec/lib/telegram/bot/client_spec.rb
+++ b/spec/lib/telegram/bot/client_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Telegram::Bot::Client do
       allow(api).to receive(:getUpdates).and_return(response)
     end
 
-    it 'returns hash' do
+    it 'calls api' do
       listen
       expect(api).to have_received(:getUpdates).exactly(2).times
     end

--- a/spec/lib/telegram/bot/client_spec.rb
+++ b/spec/lib/telegram/bot/client_spec.rb
@@ -12,11 +12,12 @@ RSpec.describe Telegram::Bot::Client do
     end
   end
 
+  # rubocop:disable RSpec/SubjectStub
   describe '#listen' do
     subject(:listen) { client.listen }
 
     let(:api) { double }
-    let(:response) { { "ok" => true, "result" => [] } }
+    let(:response) { { 'ok' => true, 'result' => [] } }
 
     before do
       allow(client).to receive(:running).and_return(true, true, false)
@@ -29,4 +30,5 @@ RSpec.describe Telegram::Bot::Client do
       expect(api).to have_received(:getUpdates).exactly(2).times
     end
   end
+  # rubocop:enable RSpec/SubjectStub
 end


### PR DESCRIPTION
I think it would be good for testing

Also remove `exit` command, in case we need to clean up after stopping listener. (and it makes testing imbossible with out mocking)