### PR TITLE
Faraday connection options for http_proxy

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -33,10 +33,11 @@ module Telegram
 
       attr_reader :token, :url, :environment
 
-      def initialize(token, url: 'https://api.telegram.org', environment: :production)
+      def initialize(token, url: 'https://api.telegram.org', environment: :production, options: nil)
         @token = token
         @url = url
         @environment = environment.downcase.to_sym
+		@cnn_options = options
       end
 
       def method_missing(method_name, *args, &block)
@@ -97,7 +98,7 @@ module Telegram
       end
 
       def conn
-        @conn ||= Faraday.new(url: url) do |faraday|
+        @conn ||= Faraday.new({url: url}, @cnn_options) do |faraday|
           faraday.request :multipart
           faraday.request :url_encoded
           faraday.adapter Telegram::Bot.configuration.adapter

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -12,7 +12,11 @@ module Telegram
 
       def initialize(token, hash = {})
         @options = default_options.merge(hash)
-        @api = Api.new(token, url: options.delete(:url), environment: options.delete(:environment))
+		cnn_options = {}
+		[:proxy, :ssl].each do |k|
+			cnn_options[k] = options.delete(k) if options.has_key?(k)
+		end
+        @api = Api.new(token, url: options.delete(:url), environment: options.delete(:environment), options: cnn_options.empty? ? nil : cnn_options)
         @logger = options.delete(:logger)
       end
 


### PR DESCRIPTION
Sometime the bot code is running behind an http proxy and the direct connection to telegram api is not possible.
I extend the client and api interfaces to permit passing the the connection options to the Faraday instance.
In my case I pass in the use_ssl flag with the proxy_address and the proxy_port parameters.

Hope this may help someone else.
