### PR TITLE
Improve RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,3 @@ Metrics/BlockLength:
 
 Layout/LineLength:
   Max: 120
-  Exclude:
-    - telegram-bot-ruby.gemspec
-    - examples/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - bin/console
-
 Metrics/BlockLength:
   AllowedMethods:
     - context

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 require:
   - rubocop-rake
   - rubocop-rspec
+  - rubocop-performance
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.4'
 
 gem 'rubocop', '~> 1.54.1'
+gem 'rubocop-performance', '~> 1.18'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-rspec', '~> 2.22.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem 'dotenv', '~> 2.8'
 gem 'nokogiri', '~> 1.13'
 gem 'pry'
 gem 'rake', '~> 13.0'
+
 gem 'rspec', '~> 3.4'
-gem 'rubocop', '~> 1.27'
-gem 'rubocop-rake'
-gem 'rubocop-rspec', '~> 2.10'
+
+gem 'rubocop', '~> 1.54.1'
+gem 'rubocop-rake', '~> 0.6.0'
+gem 'rubocop-rspec', '~> 2.22.0'

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,8 @@ task :dump_type_attributes do
   # Fetch and parse docs
   doc = Nokogiri::HTML(URI.open('https://core.telegram.org/bots/api').read)
 
+  next_type_element_names = %w[table h4]
+
   result = types.to_h do |type|
     # This is very hacky but working way to find table containing attributes for
     # given type. Basic idea is to find heading with type and then iterate until
@@ -38,7 +40,7 @@ task :dump_type_attributes do
     element = doc.at_xpath(%{//h4[text() = "#{type}"]})
     loop do
       element = element.next_element
-      break if %w[table h4].include?(element.name)
+      break if next_type_element_names.include?(element.name)
     end
 
     attributes = element.xpath('.//tbody//tr').map do |el|

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'pry'
 

--- a/lib/telegram/bot/types/compactable.rb
+++ b/lib/telegram/bot/types/compactable.rb
@@ -5,13 +5,8 @@ module Telegram
     module Types
       module Compactable
         def to_compact_hash
-          attributes.dup.delete_if { |_, v| v.nil? }.to_h do |key, value|
-            value =
-              if value.respond_to?(:to_compact_hash)
-                value.to_compact_hash
-              else
-                value
-              end
+          attributes.dup.compact.to_h do |key, value|
+            value = value.to_compact_hash if value.respond_to?(:to_compact_hash)
 
             [key, value]
           end


### PR DESCRIPTION
1. Lock its version better (new minor versions with `NewCops: enable` give new offenses).
2. Fix some new offenses.
3. Add performance plugin.