### PR TITLE
Use `require_relative` instead of `File.expand_path` and `$LOAD_PATH.unshift`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task default: :spec
 
 desc 'Dump type definitions from docs to YAML'
 task :dump_type_attributes do
-  require File.expand_path('lib/telegram/bot', __dir__)
+  require_relative 'lib/telegram/bot'
   require 'nokogiri'
   require 'open-uri'
   require 'yaml'

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,6 @@
 require 'bundler/setup'
 require 'pry'
 
-require File.expand_path('../lib/telegram/bot', __dir__)
+require_relative '../lib/telegram/bot'
 
 Pry.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require 'dotenv/load'
-require 'telegram/bot'
+require_relative '../lib/telegram/bot'

--- a/telegram-bot-ruby.gemspec
+++ b/telegram-bot-ruby.gemspec
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
-require 'telegram/bot/version'
+require_relative 'lib/telegram/bot/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'telegram-bot-ruby'


### PR DESCRIPTION
It also can prevent some errors with requiring not proper version from specs (but globally installed one).