### PR TITLE
Make `ResponseError#data` public

### DIFF
--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -13,7 +13,7 @@ module Telegram
 
         def to_s
           super +
-            format(' (%s)', data.map { |k, v| %(#{k}: "#{v}") }.join(', '))
+            format(' (%s)', data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', '))
         end
 
         def error_code

--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -20,8 +20,6 @@ module Telegram
           data[:error_code] || data['error_code']
         end
 
-        private
-
         def data
           @data ||= begin
             JSON.parse(response.body)

--- a/spec/lib/telegram/bot/exceptions/response_error_spec.rb
+++ b/spec/lib/telegram/bot/exceptions/response_error_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Telegram::Bot::Exceptions::ResponseError do
 
   let(:response) { Telegram::Bot::Api.new('123456:wrongtoken').call('getMe') }
 
-  it 'has error code' do
-    expect(error).to respond_to(:error_code)
+  describe '#error_code' do
+    subject { super().error_code }
+
+    it { is_expected.to eq 401 }
   end
 end

--- a/spec/lib/telegram/bot/exceptions/response_error_spec.rb
+++ b/spec/lib/telegram/bot/exceptions/response_error_spec.rb
@@ -26,4 +26,10 @@ RSpec.describe Telegram::Bot::Exceptions::ResponseError do
 
     it { is_expected.to eq expected_result }
   end
+
+  describe '#data' do
+    subject { super().data }
+
+    it { is_expected.to eq({ 'ok' => false, 'error_code' => 401, 'description' => 'Unauthorized' }) }
+  end
 end

--- a/spec/lib/telegram/bot/exceptions/response_error_spec.rb
+++ b/spec/lib/telegram/bot/exceptions/response_error_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe Telegram::Bot::Exceptions::ResponseError do
 
     it { is_expected.to eq 401 }
   end
+
+  describe '#to_s' do
+    subject { super().to_s }
+
+    let(:expected_result) do
+      <<~STRING.chomp
+        Telegram API has returned the error. (ok: false, error_code: 401, description: "Unauthorized")
+      STRING
+    end
+
+    it { is_expected.to eq expected_result }
+  end
 end


### PR DESCRIPTION
It's useful for checks by fields inside `rescue`, re-raise or not.

Also:
* Remake specs of `ResponseError#error_code`.
* Add specs for `ResponseError#to_s`.
* Replace double quotes for any value inside `ResponseError#to_s` with `.inspect`:
  now the type of value is more obvious (Boolean, Integer, String, etc.).