### PR TITLE
Rename `Bot::Api#conn` to `#connection` and make it public

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -56,7 +56,7 @@ module Telegram
       def call(endpoint, raw_params = {})
         params = build_params(raw_params)
         path = build_path(endpoint)
-        response = conn.post(path, params)
+        response = connection.post(path, params)
         unless response.status == 200
           raise Exceptions::ResponseError.new(response), 'Telegram API has returned the error.'
         end
@@ -96,8 +96,8 @@ module Telegram
         words.join
       end
 
-      def conn
-        @conn ||= Faraday.new(url: url) do |faraday|
+      def connection
+        @connection ||= Faraday.new(url: url) do |faraday|
           faraday.request :multipart
           faraday.request :url_encoded
           faraday.adapter Telegram::Bot.configuration.adapter

--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -39,6 +39,16 @@ module Telegram
         @environment = environment.downcase.to_sym
       end
 
+      def connection
+        @connection ||= Faraday.new(url: url) do |faraday|
+          faraday.request :multipart
+          faraday.request :url_encoded
+          faraday.adapter Telegram::Bot.configuration.adapter
+          faraday.options.timeout = Telegram::Bot.configuration.connection_timeout
+          faraday.options.open_timeout = Telegram::Bot.configuration.connection_open_timeout
+        end
+      end
+
       def method_missing(method_name, *args, &block)
         endpoint = method_name.to_s
         endpoint = camelize(endpoint) if endpoint.include?('_')
@@ -94,16 +104,6 @@ module Telegram
         words = method_name.split('_')
         words.drop(1).map(&:capitalize!)
         words.join
-      end
-
-      def connection
-        @connection ||= Faraday.new(url: url) do |faraday|
-          faraday.request :multipart
-          faraday.request :url_encoded
-          faraday.adapter Telegram::Bot.configuration.adapter
-          faraday.options.timeout = Telegram::Bot.configuration.connection_timeout
-          faraday.options.open_timeout = Telegram::Bot.configuration.connection_open_timeout
-        end
       end
     end
   end


### PR DESCRIPTION
I see no reason to shrink it's like this.

Also I'm thinking to make it's public:
can be helpful for adding middlewares, such as `:logger`, but maybe I'll consider changes to the `Bot::Configuration` later.

---

Update: I've decided to make it public, because don't know how to add `connection.response :logger, nil, { headers: true, bodies: true }` into `Configuration` with flexible customization. It seems just easier to call `connection` from outside as you want.