### PR TITLE
Improve `ResponseError`

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -58,7 +58,7 @@ module Telegram
         path = build_path(endpoint)
         response = conn.post(path, params)
         unless response.status == 200
-          raise Exceptions::ResponseError.new(response), 'Telegram API has returned the error.'
+          raise Exceptions::ResponseError.new(response)
         end
 
         JSON.parse(response.body)

--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -57,9 +57,7 @@ module Telegram
         params = build_params(raw_params)
         path = build_path(endpoint)
         response = conn.post(path, params)
-        unless response.status == 200
-          raise Exceptions::ResponseError.new(response)
-        end
+        raise Exceptions::ResponseError.new(response: response) unless response.status == 200
 
         JSON.parse(response.body)
       end

--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -8,12 +8,8 @@ module Telegram
 
         def initialize(response)
           @response = response
-          super
-        end
 
-        def to_s
-          super +
-            format(' (%s)', data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', '))
+          super "Telegram API has returned the error. (#{data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', ')})"
         end
 
         def error_code

--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -6,7 +6,7 @@ module Telegram
       class ResponseError < Base
         attr_reader :response
 
-        def initialize(response)
+        def initialize(response:)
           @response = response
 
           super "Telegram API has returned the error. (#{data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', ')})"

--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -13,7 +13,7 @@ module Telegram
 
         def to_s
           super +
-            format(' (%s)', data.map { |k, v| %(#{k}: "#{v}") }.join(', '))
+            format(' (%s)', data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', '))
         end
 
         def error_code

--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -20,8 +20,6 @@ module Telegram
           data[:error_code] || data['error_code']
         end
 
-        private
-
         def data
           @data ||= begin
             JSON.parse(response.body)

--- a/spec/lib/telegram/bot/api_spec.rb
+++ b/spec/lib/telegram/bot/api_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe Telegram::Bot::Api do
       let(:token) { '123456:wrongtoken' }
 
       it 'raises an error' do
-        expect { api_call }
-          .to raise_error(Telegram::Bot::Exceptions::ResponseError)
+        expect { api_call }.to raise_error(
+          Telegram::Bot::Exceptions::ResponseError,
+          'Telegram API has returned the error. (ok: false, error_code: 401, description: "Unauthorized")'
+        )
       end
     end
 

--- a/spec/lib/telegram/bot/exceptions/response_error_spec.rb
+++ b/spec/lib/telegram/bot/exceptions/response_error_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Telegram::Bot::Exceptions::ResponseError do
 
   let(:response) { Telegram::Bot::Api.new('123456:wrongtoken').call('getMe') }
 
-  it 'has error code' do
-    expect(error).to respond_to(:error_code)
+  describe '#error_code' do
+    subject { super().error_code }
+
+    it { is_expected.to eq 401 }
   end
 end

--- a/spec/lib/telegram/bot/exceptions/response_error_spec.rb
+++ b/spec/lib/telegram/bot/exceptions/response_error_spec.rb
@@ -26,4 +26,10 @@ RSpec.describe Telegram::Bot::Exceptions::ResponseError do
 
     it { is_expected.to eq expected_result }
   end
+
+  describe '#data' do
+    subject { super().data }
+
+    it { is_expected.to eq({ 'ok' => false, 'error_code' => 401, 'description' => 'Unauthorized' }) }
+  end
 end

--- a/spec/lib/telegram/bot/exceptions/response_error_spec.rb
+++ b/spec/lib/telegram/bot/exceptions/response_error_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe Telegram::Bot::Exceptions::ResponseError do
 
     it { is_expected.to eq 401 }
   end
+
+  describe '#to_s' do
+    subject { super().to_s }
+
+    let(:expected_result) do
+      <<~STRING.chomp
+        Telegram API has returned the error. (ok: false, error_code: 401, description: "Unauthorized")
+      STRING
+    end
+
+    it { is_expected.to eq expected_result }
+  end
 end


### PR DESCRIPTION
* Make `ResponseError#data` public.
  It's useful for checks by fields inside `rescue`, re-raise or not.
* Remake specs of `ResponseError#error_code`.
* Add specs for `ResponseError#to_s`.
* Replace double quotes for any value inside `ResponseError#to_s` with `.inspect`:
  now the type of value is more obvious (Boolean, Integer, String, etc.).
* Improve `ResponseError` initialization.
  Don't expect basic message, have it inside the class.