### PR TITLE
Add `Bot::Client#stop` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ end
 Same thing about `message` object: it implements [Message](https://core.telegram.org/bots/api#message) spec,
 so you always know what to expect from it.
 
+To gracefully stop the bot, for example by `INT` signal (Ctrl-C), call the `bot.stop` method:
+
+```ruby
+bot = Telegram::Bot::Client.new(token)
+
+Signal.trap('INT') do
+  bot.stop
+end
+
+bot.listen do |message|
+  # it will be in an infinity loop until `bot.stop` command
+  # (with a small delay for the current `fetch_updates` request)
+end
+```
+
 ## Webhooks
 
 If you are going to use [webhooks](https://core.telegram.org/bots/api#setwebhook)

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -22,10 +22,12 @@ module Telegram
 
       def listen(&block)
         logger.info('Starting bot')
-        running = true
-        Signal.trap('INT') { running = false }
-        fetch_updates(&block) while running
-        exit
+        @running = true
+        fetch_updates(&block) while @running
+      end
+
+      def stop
+        @running = false
       end
 
       def fetch_updates

--- a/spec/lib/telegram/bot/client_spec.rb
+++ b/spec/lib/telegram/bot/client_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe Telegram::Bot::Client, :vcr do
     end
   end
 
+  describe '#stop' do
+    before do
+      allow(client.api).to receive(:getUpdates).and_return [Telegram::Bot::Types::Update.new(update_id: 111_111)]
+
+      current_times = 0
+
+      client.listen do |_message|
+        current_times += 1
+        client.stop if current_times == expected_times
+      end
+    end
+
+    let(:expected_times) { 3 }
+
+    specify do
+      expect(client.api).to have_received(:getUpdates).exactly(expected_times).times
+    end
+  end
+
   describe '#fetch_updates' do
     before do
       allow(client.api).to receive(:call).with('getUpdates', hash_including(offset: 0)).and_return(


### PR DESCRIPTION
1. Add an ability to stop bot's infinity loop from outside.
2. Remove `exit` which kills any (parent) process with a bot, like specs.