### PR TITLE
Enable Ruby warnings for RSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper
 --color
+--warnings


### PR DESCRIPTION
It's useful to detect Ruby warnings, some coming changes. (Fortunatelly, there are no warnings for now)