### PR TITLE
Fix infinite loop on Timeout while stopped

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -35,7 +35,7 @@ module Telegram
           yield handle_update(update)
         end
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed
-        retry
+        retry if @running
       end
 
       def handle_update(update)


### PR DESCRIPTION
Current version gets stuck in a loop of reconnections if the bot does not receive any messages even though it received `#stop`