### PR TITLE
Make it possible to read updates in listening mode

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -40,10 +40,17 @@ module Telegram
 
       def handle_update(update)
         @options[:offset] = update.update_id.next
-        message = update.current_message
-        log_incoming_message(message)
 
-        message
+        if @options[:listen_update_mode]
+          log_incoming_update(update)
+
+          update
+        else
+          message = update.current_message
+          log_incoming_message(message)
+
+          message
+        end
       end
 
       private
@@ -62,6 +69,12 @@ module Telegram
         uid = message.respond_to?(:from) && message.from ? message.from.id : nil
         logger.info(
           format('Incoming message: text="%<message>s" uid=%<uid>s', message: message, uid: uid)
+        )
+      end
+
+      def log_incoming_update(update)
+        logger.info(
+          format('Incoming update: uid=%<uid>s', uid: update.update_id)
         )
       end
     end

--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -39,9 +39,9 @@ module Telegram
       end
 
       def handle_update(update)
-        @options[:offset] = update.update_id.next
+        options[:offset] = update.update_id.next
 
-        if @options[:listen_update_mode]
+        if options[:listen_update_mode]
           log_incoming_update(update)
 
           update

--- a/lib/telegram/bot/exceptions/response_error.rb
+++ b/lib/telegram/bot/exceptions/response_error.rb
@@ -9,7 +9,7 @@ module Telegram
         def initialize(response:)
           @response = response
 
-          super "Telegram API has returned the error. (#{data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', ')})"
+          super("Telegram API has returned the error. (#{data.map { |k, v| %(#{k}: #{v.inspect}) }.join(', ')})")
         end
 
         def error_code


### PR DESCRIPTION
I had a need for the bot to read all incoming updates when it was in polling mode, not just messages. This is very useful when, for example, you need the bot to work in polling mode in one environment and via webhooks in another, without changing the code itself.

It will look like this:
```ruby
  Telegram::Bot::Client.run(token, listen_update_mode: true) do |bot|
    bot.listen do |update|
      # something
    end
  end
```