### PR TITLE
Fix changelog to have correct links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ### Added
 
-- [Bot API 8.1](https://core.telegram.org/bots/api-changelog#october-31-2024) [#319](https://github.com/atipugin/telegram-bot-ruby/pull/319)
+- [Bot API 8.1](https://core.telegram.org/bots/api-changelog#december-4-2024) [#319](https://github.com/atipugin/telegram-bot-ruby/pull/319)
 
 ## 2.1.0
 
 ### Added
 
-- [Bot API 8.0](https://core.telegram.org/bots/api#november-17-2024) (thx [@seorgiy](https://github.com/seorgiy))
+- [Bot API 8.0](https://core.telegram.org/bots/api-changelog#november-17-2024) (thx [@seorgiy](https://github.com/seorgiy))
 
 ## 2.0.0
 
 ### Added
 
-- [Bot API 7.0](https://core.telegram.org/bots/api#december-29-2023)
+- [Bot API 7.0](https://core.telegram.org/bots/api-changelog#december-29-2023)
 
 ### Changed
 
@@ -26,8 +26,8 @@
 
 - Replace [virtus](https://github.com/solnic/virtus) with [dry-struct](https://github.com/dry-rb/dry-struct)
 - Use [zeitwerk](https://github.com/fxn/zeitwerk) for code loading
-- Implement [Bot API 6.4](https://core.telegram.org/bots/api#december-30-2022)
-- Implement [Bot API 6.5](https://core.telegram.org/bots/api#february-3-2023)
+- Implement [Bot API 6.4](https://core.telegram.org/bots/api-changelog#december-30-2022)
+- Implement [Bot API 6.5](https://core.telegram.org/bots/api-changelog#february-3-2023)
 
 ## 0.23.0
 
@@ -38,8 +38,8 @@
 
 ## 0.21.0
 
-- Implement [Bot API 6.1](https://core.telegram.org/bots/api#june-20-2022)
-- Implement [Bot API 6.2](https://core.telegram.org/bots/api#august-12-2022)
+- Implement [Bot API 6.1](https://core.telegram.org/bots/api-changelog#june-20-2022)
+- Implement [Bot API 6.2](https://core.telegram.org/bots/api-changelog#august-12-2022)
 
 ## 0.20.0
 
@@ -70,11 +70,11 @@
 
 ## 0.15.0
 
-- Implement [Bot API 5.1](https://core.telegram.org/bots/api#march-9-2021)
+- Implement [Bot API 5.1](https://core.telegram.org/bots/api-changelog#march-9-2021)
 
 ## 0.14.0
 
-- Implement [Bot API 5.0](https://core.telegram.org/bots/api#november-4-2020)
+- Implement [Bot API 5.0](https://core.telegram.org/bots/api-changelog#november-4-2020)
 
 ## 0.13.0
 
@@ -88,7 +88,7 @@
 
 ## 0.11.0
 
-- Implement [Bot API 4.4](https://core.telegram.org/bots/api#july-29-2019)
+- Implement [Bot API 4.4](https://core.telegram.org/bots/api-changelog#july-29-2019)
 
 ## 0.10.1
 
@@ -96,7 +96,7 @@
 
 ## 0.10.0
 
-- Implement [Bot API 4.3](https://core.telegram.org/bots/api#may-31-2019)
+- Implement [Bot API 4.3](https://core.telegram.org/bots/api-changelog#may-31-2019)
 
 ## 0.9.1
 
@@ -115,23 +115,23 @@
 
 ## 0.8.6
 
-- Implement [Bot API 3.5](https://core.telegram.org/bots/api#november-17-2017)
+- Implement [Bot API 3.5](https://core.telegram.org/bots/api-changelog#november-17-2017)
 
 ## 0.8.5
 
-- Implement [Bot API 3.4](https://core.telegram.org/bots/api#october-11-2017) (thx [@ivanovaleksey][])
+- Implement [Bot API 3.4](https://core.telegram.org/bots/api-changelog#october-11-2017) (thx [@ivanovaleksey][])
 
 ## 0.8.4
 
-- Implement [Bot API 3.3](https://core.telegram.org/bots/api#august-23-2017) (thx [@ivanovaleksey][])
+- Implement [Bot API 3.3](https://core.telegram.org/bots/api-changelog#august-23-2017) (thx [@ivanovaleksey][])
 
 ## 0.8.3
 
-- Implement [Bot API 3.2](https://core.telegram.org/bots/api#july-21-2017) (thx [@ivanovaleksey][])
+- Implement [Bot API 3.2](https://core.telegram.org/bots/api-changelog#july-21-2017) (thx [@ivanovaleksey][])
 
 ## 0.8.2
 
-- Implement [Bot API 3.1](https://core.telegram.org/bots/api#june-30-2017) (thx [@ivanovaleksey][])
+- Implement [Bot API 3.1](https://core.telegram.org/bots/api-changelog#june-30-2017) (thx [@ivanovaleksey][])
 
 ## 0.8.1
 
@@ -139,7 +139,7 @@
 
 ## 0.8.0
 
-- Implement [Bot API 3.0](https://core.telegram.org/bots/api#may-18-2017) (thx [@ivanovaleksey][])
+- Implement [Bot API 3.0](https://core.telegram.org/bots/api-changelog#may-18-2017) (thx [@ivanovaleksey][])
 
 ## 0.7.2
 


### PR DESCRIPTION
Seems like Telegram changes links format a little bit, so older links do not work properly

I've checked most of them after the fix - all seems good