### PR TITLE
intercept ssl_read eof error in fetch_updates

### DIFF
--- a/lib/telegram/bot/client.rb
+++ b/lib/telegram/bot/client.rb
@@ -36,6 +36,10 @@ module Telegram
         end
       rescue Faraday::TimeoutError, Faraday::ConnectionFailed
         retry if @running
+      rescue Faraday::SSLError => e
+        raise unless e.message.include?('SSL_read: unexpected eof while reading')
+
+        retry if @running
       end
 
       def handle_update(update)


### PR DESCRIPTION
[My bot](https://github.com/projecteurlumiere/vpn_generator_distributor) has been encountering the following error once in every couple of days in the production environment:

```
Faraday::SSLError: SSL_read: unexpected eof while reading
```

While any API request can encounter this error, it's very annoying with `get_updates` because it kills the bot right away.

I found out it's possible to configure OpenSSL to ignore unexpected eof errors - see [docs](https://docs.openssl.org/master/man3/SSL_CTX_set_options/#notes) for `SSL_OP_IGNORE_UNEXPECTED_EOF` setting. In the bot's case, however, the next retry always succeeds, so I presume it might be a genuine network error, not a persistent configuration error on Telegram's side.

Alternatively, this fix might belong at a lower level, not here. Yet, I've been using [quite basic Debian setup](https://github.com/projecteurlumiere/vpn_generator_distributor/blob/main/Dockerfile), and solving this problem turned up to be extremely frustrating as I really wasn't expecting `get_updates` to shut down like this.

We also might want to log this particular error before retrying but I am unsure.