### PR TITLE
Jsonify hash value

### DIFF
--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -73,7 +73,7 @@ module Telegram
       end
 
       def jsonify_value?(value)
-        value.respond_to?(:to_compact_hash) || value.is_a?(Array)
+        value.respond_to?(:to_compact_hash) || value.is_a?(Array) || value.is_a?(Hash)
       end
 
       def camelize(method_name)


### PR DESCRIPTION
While starting to work with the library, I spot that using `reply_parameters` with `message_id` does not work.

The example below will always send just text message, without reply
```rb
 bot.api.send_message(chat_id: message.chat.id, text: "#{message.from.id}", reply_parameters: { message_id: message.message_id })
```

I can't be 100% sure, but if I understand it correctly:  
Try to pass Hash into `reply_parameters` 
Hash is not an Array or respond to `to_compact_hash` since Message type does not implement this method

And Faraday flatten it to something like `reply_parameters[message_id]=51`