### PR TITLE
Fix Rich Messages: JSON-encode Hash params and parse RichText correctly

### DIFF
--- a/data/types.json
+++ b/data/types.json
@@ -5028,6 +5028,8 @@
   },
   "RichText": {
     "type": [
+      "string",
+      "array:RichText",
       "RichTextBold",
       "RichTextItalic",
       "RichTextUnderline",

--- a/lib/telegram/bot/api.rb
+++ b/lib/telegram/bot/api.rb
@@ -85,7 +85,7 @@ module Telegram
       end
 
       def jsonify_value?(value)
-        value.respond_to?(:to_compact_hash) || value.is_a?(Array)
+        value.respond_to?(:to_compact_hash) || value.is_a?(Array) || value.is_a?(Hash)
       end
 
       def camelize(method_name)

--- a/lib/telegram/bot/types/rich_text.rb
+++ b/lib/telegram/bot/types/rich_text.rb
@@ -6,6 +6,8 @@ module Telegram
       ## Just for classes consistency
       # rubocop:disable Naming/ConstantName
       RichText = (
+        Types::String |
+        Types::Array.of(Types.deferred(:RichText)) |
         RichTextBold |
         RichTextItalic |
         RichTextUnderline |

--- a/rakelib/builders/type_builder.rb
+++ b/rakelib/builders/type_builder.rb
@@ -38,21 +38,15 @@ module Builders
     end
 
     def build_empty_type
-      attrs = Array(attributes[:type]).map { |member| empty_type_member(member.to_s) }
-                                      .join(" |\n        ")
+      attrs = attributes[:type].map { |member| empty_type_member(member.to_s) }
+                               .join(" |\n        ")
       render_template('empty_type.erb', name: name, attributes: attrs)
     end
 
-    # Docs unions may include "string" / "array:Name" alongside struct members.
     def empty_type_member(member)
-      return 'Types::String' if member == 'string'
+      return "Types::Array.of(#{add_module_types(member.delete_prefix('array:'))})" if member.start_with?('array:')
 
-      if member.start_with?('array:')
-        target = member.delete_prefix('array:')
-        return "Types::Array.of(Types.deferred(:#{target}))"
-      end
-
-      member
+      add_module_types(member)
     end
 
     def build_full_type

--- a/rakelib/builders/type_builder.rb
+++ b/rakelib/builders/type_builder.rb
@@ -38,8 +38,21 @@ module Builders
     end
 
     def build_empty_type
-      attrs = attributes[:type].join(" |\n        ")
+      attrs = Array(attributes[:type]).map { |member| empty_type_member(member.to_s) }
+                                      .join(" |\n        ")
       render_template('empty_type.erb', name: name, attributes: attrs)
+    end
+
+    # Docs unions may include "string" / "array:Name" alongside struct members.
+    def empty_type_member(member)
+      return 'Types::String' if member == 'string'
+
+      if member.start_with?('array:')
+        target = member.delete_prefix('array:')
+        return "Types::Array.of(Types.deferred(:#{target}))"
+      end
+
+      member
     end
 
     def build_full_type

--- a/rakelib/parsers/types_parser.rb
+++ b/rakelib/parsers/types_parser.rb
@@ -80,10 +80,11 @@ module Parsers
     end
 
     def parse_union_type(ul_element, description, type_name)
-      types = ul_element.css('li a').map { |a| a.text.strip }
+      types = []
       desc_text = description&.text.to_s
-      types = ['string', *types] if desc_text.match?(/String for plain text/i)
-      types = ["array:#{type_name}", *types] if desc_text.match?(/an Array of #{type_name}/i)
+      types << 'string' if desc_text.match?(/String for plain text/i)
+      types << "array:#{type_name}" if desc_text.match?(/an Array of #{type_name}/i)
+      types.concat(ul_element.css('li a').map { |a| a.text.strip })
       { 'type' => types.uniq }
     end
 

--- a/rakelib/parsers/types_parser.rb
+++ b/rakelib/parsers/types_parser.rb
@@ -51,15 +51,21 @@ module Parsers
       name
     end
 
-    def parse_type(header, _type_name)
+    def parse_type(header, type_name)
       # Check if this is a union type (list of types without a table)
+      description = first_description_paragraph(header)
       next_sibling = find_next_significant_sibling(header)
 
       if union_type?(next_sibling)
-        parse_union_type(next_sibling)
+        parse_union_type(next_sibling, description, type_name)
       else
         parse_table_type(header)
       end
+    end
+
+    def first_description_paragraph(header)
+      sibling = header.next_element
+      sibling if sibling&.name == 'p'
     end
 
     def find_next_significant_sibling(header)
@@ -73,9 +79,12 @@ module Parsers
       element&.name == 'ul'
     end
 
-    def parse_union_type(ul_element)
+    def parse_union_type(ul_element, description, type_name)
       types = ul_element.css('li a').map { |a| a.text.strip }
-      { 'type' => types }
+      desc_text = description&.text.to_s
+      types = ['string', *types] if desc_text.match?(/String for plain text/i)
+      types = ["array:#{type_name}", *types] if desc_text.match?(/an Array of #{type_name}/i)
+      { 'type' => types.uniq }
     end
 
     def parse_table_type(header)

--- a/spec/lib/telegram/bot/api_spec.rb
+++ b/spec/lib/telegram/bot/api_spec.rb
@@ -302,4 +302,35 @@ RSpec.describe Telegram::Bot::Api, :vcr do
       end
     end
   end
+
+  describe '#build_params / nested JSON encoding' do
+    subject(:params) { api.send(:build_params, raw) }
+
+    let(:token) { '123456:TEST' }
+    let(:environment) { :test }
+
+    context 'when rich_message is a Hash' do
+      let(:raw) { { chat_id: 1, rich_message: { markdown: '**hi**' } } }
+
+      it 'JSON-encodes the nested hash' do
+        expect(params[:rich_message]).to eq({ markdown: '**hi**' }.to_json)
+      end
+    end
+
+    context 'when reply_parameters is a Hash' do
+      let(:raw) { { chat_id: 1, reply_parameters: { message_id: 42 } } }
+
+      it 'JSON-encodes reply_parameters' do
+        expect(params[:reply_parameters]).to eq({ message_id: 42 }.to_json)
+      end
+    end
+
+    context 'when value is a plain string' do
+      let(:raw) { { chat_id: 1, text: 'hello' } }
+
+      it 'leaves scalars untouched' do
+        expect(params).to include(text: 'hello', chat_id: 1)
+      end
+    end
+  end
 end

--- a/spec/lib/telegram/bot/types_spec.rb
+++ b/spec/lib/telegram/bot/types_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe Telegram::Bot::Types do
     describe class_name do
       subject(:klass) { described_class.const_get(class_name, false) }
 
-      # empty classes exception
+      # empty / union types have no schema
       next if described_class.const_get(class_name, false).instance_of?(Dry::Struct::Sum)
+      next unless described_class.const_get(class_name, false).respond_to?(:schema)
 
       it 'has correct attributes' do
         expect(klass.schema.keys.map(&:name)).to eq(attributes.keys.map(&:to_sym))
@@ -82,6 +83,42 @@ RSpec.describe Telegram::Bot::Types do
 
     it 'round-trips through to_h' do
       expect(rich_message.to_h).to eq(payload)
+    end
+  end
+
+  describe 'RichText plain string and array forms' do
+    subject(:message) { described_class::RichMessage.new(payload) }
+
+    let(:payload) { { blocks: [{ type: 'paragraph', text: text }] } }
+
+    context 'with a plain string leaf' do
+      let(:text) { 'hello' }
+
+      it { expect(message.blocks.first.text).to eq('hello') }
+    end
+
+    context 'with nested bold wrapping a plain string' do
+      let(:text) { { type: 'bold', text: 'Hello' } }
+
+      it { expect(message.blocks.first.text).to have_attributes(class: described_class::RichTextBold, text: 'Hello') }
+    end
+
+    context 'with an array of mixed rich text segments' do
+      let(:text) { ['Hello ', { type: 'bold', text: 'world' }, '!'] }
+
+      it 'coerces segments in place' do
+        expect(message.blocks.first.text).to match(
+          ['Hello ', an_instance_of(described_class::RichTextBold).and(have_attributes(text: 'world')), '!']
+        )
+      end
+    end
+
+    context 'with string-keyed JSON-like hashes' do
+      let(:payload) do
+        { 'blocks' => [{ 'type' => 'paragraph', 'text' => { 'type' => 'bold', 'text' => 'Hello from JSON' } }] }
+      end
+
+      it { expect { message }.not_to raise_error }
     end
   end
 end

--- a/spec/rakelib/builders/type_builder_spec.rb
+++ b/spec/rakelib/builders/type_builder_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative '../../../rakelib/builders/type_builder'
+require_relative '../../../rakelib/builders/type_dependencies'
+
+RSpec.describe Builders::TypeBuilder do
+  subject(:builder) do
+    described_class.new(
+      type_name,
+      attributes,
+      templates_dir: templates_dir,
+      dependencies: dependencies
+    )
+  end
+
+  let(:templates_dir) { File.expand_path('../../../rakelib/templates', __dir__) }
+  let(:type_name) { 'RichText' }
+  let(:attributes) { { type: members } }
+  let(:members) { %w[string array:RichText RichTextBold] }
+  let(:types) do
+    {
+      'RichText' => { type: members },
+      'RichTextBold' => {
+        type: { type: 'string', required: true, required_value: 'bold' },
+        text: { type: 'string', required: true }
+      }
+    }
+  end
+  let(:dependencies) { Builders::TypeDependencies.new(types) }
+
+  describe '#build for empty (sum) types' do
+    subject(:output) { builder.build }
+
+    it 'maps string members to Types::String first' do
+      expect(output).to match(/RichText = \(\s*Types::String\s*\|/m)
+    end
+
+    it 'maps array:Name members to deferred Array.of' do
+      expect(output).to include('Types::Array.of(Types.deferred(:RichText))')
+    end
+
+    it 'keeps struct member names as-is' do
+      expect(output).to include("RichTextBold\n")
+    end
+
+    it 'emits a valid empty-type module shell' do
+      expect(output).to match(/module Telegram\b.*\bRichText = \(.*\)/m)
+    end
+
+    context 'with only struct members' do
+      let(:members) { %w[ChatMemberOwner ChatMemberAdministrator] }
+
+      it 'joins struct members without string/array wrappers' do
+        expect(output).to match(
+          /ChatMemberOwner\s*\|\s*ChatMemberAdministrator\n/
+        ).and(satisfy { |body| !body.include?('Types::String') && !body.include?('Types::Array') })
+      end
+    end
+  end
+end

--- a/spec/rakelib/parsers/types_parser_spec.rb
+++ b/spec/rakelib/parsers/types_parser_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require_relative '../../../rakelib/parsers/types_parser'
+
+RSpec.describe Parsers::TypesParser do
+  subject(:parser) { described_class.new }
+
+  describe '#parse_union_type' do
+    def parse_union(description_html, list_items, type_name = 'RichText')
+      description = Nokogiri::HTML.fragment(description_html).children.find(&:element?)
+      ul_html = list_items.map { |name| %(<li><a href="##{name}">#{name}</a></li>) }.join
+      ul = Nokogiri::HTML.fragment("<ul>#{ul_html}</ul>").at('ul')
+
+      parser.send(:parse_union_type, ul, description, type_name)
+    end
+
+    it 'collects linked struct members from the union list' do
+      result = parse_union('<p>This object represents something.</p>', %w[RichTextBold RichTextItalic])
+
+      expect(result).to eq('type' => %w[RichTextBold RichTextItalic])
+    end
+
+    it 'prepends string when prose mentions plain text strings' do
+      result = parse_union(
+        '<p>This object represents rich text. String for plain text, or one of:</p>',
+        %w[RichTextBold]
+      )
+
+      expect(result['type']).to eq(%w[string RichTextBold])
+    end
+
+    it 'prepends array:TypeName when prose mentions an Array of the type' do
+      result = parse_union(
+        '<p>This object represents rich text as an Array of RichText, or one of:</p>',
+        %w[RichTextBold]
+      )
+
+      expect(result['type']).to eq(%w[array:RichText RichTextBold])
+    end
+
+    it 'prepends both string and array when both are described' do
+      result = parse_union(
+        '<p>String for plain text, an Array of RichText for sequences, or one of:</p>',
+        %w[RichTextBold RichTextItalic]
+      )
+
+      # array is applied after string, so it ends up first among the synthetic members
+      expect(result['type']).to eq(%w[array:RichText string RichTextBold RichTextItalic])
+    end
+
+    it 'deduplicates members' do
+      result = parse_union(
+        '<p>String for plain text or one of:</p>',
+        %w[string RichTextBold]
+      )
+
+      # "string" from prose plus a hypothetical linked "string" collapse via uniq
+      expect(result['type']).to eq(%w[string RichTextBold])
+    end
+  end
+end

--- a/spec/rakelib/parsers/types_parser_spec.rb
+++ b/spec/rakelib/parsers/types_parser_spec.rb
@@ -39,14 +39,13 @@ RSpec.describe Parsers::TypesParser do
       expect(result['type']).to eq(%w[array:RichText RichTextBold])
     end
 
-    it 'prepends both string and array when both are described' do
+    it 'keeps string before array when both are described' do
       result = parse_union(
         '<p>String for plain text, an Array of RichText for sequences, or one of:</p>',
         %w[RichTextBold RichTextItalic]
       )
 
-      # array is applied after string, so it ends up first among the synthetic members
-      expect(result['type']).to eq(%w[array:RichText string RichTextBold RichTextItalic])
+      expect(result['type']).to eq(%w[string array:RichText RichTextBold RichTextItalic])
     end
 
     it 'deduplicates members' do


### PR DESCRIPTION
## Summary

Fixes two bugs that break Bot API Rich Messages (`sendRichMessage` / response parsing of `RichMessage`).

### 1. Nested Hash params were not JSON-encoded on send

**Symptom:** Telegram rejected `sendRichMessage` with `rich message must be non-empty` (and similar empty-body failures for other nested objects).

**Cause:** `Telegram::Bot::Api` only JSON-encoded `Array` and `Compactable` values before building the multipart/form request. Plain Ruby `Hash` values (e.g. `rich_message: { … }`, `reply_parameters: { … }`) were sent as form fields and never reached Telegram as a structured object.

**Change:** Also call `.to_json` for `Hash` parameters in `Api#call`.

### 2. Response parsing of `RichText` failed and flooded exceptions

**Symptom:** After a successful send, parsing the API response raised / logged a flood of `Dry::Struct::Error` (often visible via Sentry or similar).

**Cause:** Per [Bot API docs](https://core.telegram.org/bots/api#richtext), `RichText` may be a plain `String`, an `Array` of `RichText`, or a typed object. The generated type only listed the struct variants, so a plain-text string was tried against every branch and failed to convert.

**Change:** Put `Types::String` and `Types::Array.of(Types.deferred(:RichText))` at the beginning of the `RichText` union so plain text and arrays coerce early:

```ruby
RichText = (
  Types::String |
  Types::Array.of(Types.deferred(:RichText)) |
  RichTextBold |
  ...
)
```

Also update the source of truth so regenerating types keeps the fix:
- `data/types.json` — `string` / `array:RichText` members
- docs parser — extracts those members from the API description prose
- type builder — maps them to dry-types expressions on rebuild

## Test plan

- [x] `bundle exec rspec` (unit suite green locally)
- [x] Specs cover Hash JSON-encoding in `Api` and `RichText` string/array/typed coercion
- [ ] Manual: `send_rich_message` with a markdown/plain rich payload; confirm send succeeds and response parses without `Dry::Struct` noise


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich text now supports plain text, nested rich-text content, and arrays of rich-text values.
  * Rich-text content can be provided in JSON-like hash formats.

* **Bug Fixes**
  * Nested message parameters containing structured data are now encoded correctly when sent through the API.

* **Tests**
  * Expanded coverage for rich-text formats, nested content, type handling, and parameter serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->